### PR TITLE
Fix GRPC version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,8 @@ setup(
         'twine',
         'bottle',
         'Paste',
-        'grpcio==1.23.0',
-        'grpcio-tools==1.23.0',
+        'grpcio==1.24.1'
+        'grpcio-tools==1.24.1',
         'bottle-cors'
     ],
     classifiers=[


### PR DESCRIPTION
The package as it is can't be built on most systems, because of https://github.com/grpc/grpc/pull/18950, which is only present from grpcio 1.24 on. I've changed `setup.py` to reflect what's already in `requirements.txt`. I haven't bumped it to a more recent version because I don't know what the consequences might be.

See also #1 