### PR TITLE
Syntax error in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'twine',
         'bottle',
         'Paste',
-        'grpcio==1.24.1'
+        'grpcio==1.24.1',
         'grpcio-tools==1.24.1',
         'bottle-cors'
     ],


### PR DESCRIPTION
There is a missing comma char in the `install_requires` array syntax